### PR TITLE
Add Stinga release and standardize formatting

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
         "@biomejs/biome": "^2.4.11",
         "@svgr/webpack": "^8.1.0",
         "husky": "^8.0.0",
+        "prettier": "^3.8.1",
       },
     },
   },
@@ -1305,6 +1306,8 @@
     "postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
 
     "prebuild-install": ["prebuild-install@7.1.1", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^1.0.1", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": "bin.js" }, "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw=="],
+
+    "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 

--- a/content/releases/_meta.js
+++ b/content/releases/_meta.js
@@ -5,4 +5,5 @@ export default {
   ocelot: "🐈‍⬛ Ocelot",
   singa: "🦁 SINGA",
   unikorn: "🦄 Unikorn (w. TGR)",
+  stinga: "Stinga",
 };

--- a/content/releases/jaguar.mdx
+++ b/content/releases/jaguar.mdx
@@ -11,15 +11,13 @@ WIP
 
 ## Specifications
 
-**Form factor:** 84/87 Tenkeyless
-
-**Mounting Style:** Top Mount (R1) | Top Mount / O-ring mount (R2)
-
-**Typing Angle:** 6°
-
-**Dimensions:** 364mm x 144mm x 33mm
-
-**Front height:** 19mm
+| Spec               | Details                                          |
+| ------------------ | ------------------------------------------------ |
+| **Form factor**    | 84/87 Tenkeyless                                 |
+| **Mounting Style** | Top Mount (R1) \| Top Mount / O-ring mount (R2)  |
+| **Typing Angle**   | 6°                                               |
+| **Dimensions**     | 364mm x 144mm x 33mm                            |
+| **Front height**   | 19mm                                             |
 
 ## Layout
 
@@ -60,10 +58,10 @@ Commissions for this iteration of Jaguar were made available.
 
 #### Changes from previous versions
 
-- Changed mounting to 7 Point Top Mount (Koala,Jane v2) and O-ring/X-ring with Screw-in Stabilizer support
-- Improved and lowered USB port.
+- Changed mounting to 7 Point Top Mount (Koala, Jane v2) and O-ring/X-ring with Screw-in Stabilizer support
+- Improved and lowered USB port
 - Dual Weights (Internal is optional)
-- Added Winkeyless.
+- Added Winkeyless
 
 #### Colors
 

--- a/content/releases/kohaku.mdx
+++ b/content/releases/kohaku.mdx
@@ -11,17 +11,14 @@ WIP
 
 ## Specifications
 
-**Form factor:** 65%
-
-**Mounting Style:** Gasket mount
-
-**Typing Angle:** 8°
-
-**Dimensions:** WIP
-
-**Front height:** 19mm
-
-**Average build weight:** : Approx. 2000g (R2)
+| Spec                | Details                                   |
+| ------------------- | ----------------------------------------- |
+| **Form factor**     | 65%                                       |
+| **Mounting Style**  | Gasket mount                              |
+| **Typing Angle**    | 8°                                        |
+| **Dimensions**      | WIP                                       |
+| **Front height**    | 19mm                                      |
+| **Expected Weight** | Built: 1900+ grams, Unbuilt: 1500+ grams |
 
 ## Layout
 
@@ -50,34 +47,69 @@ WIP
 
 #### Colors
 
-- Red
-- Gray
-- Silver
+| Color      | Weight             |
+| ---------- | ------------------ |
+| **Red**    | Sandblasted copper |
+| **Gray**   | Sandblasted copper |
+| **Silver** | Sandblasted copper |
 
-### R2 (2023, 2024)
+### R2 (2023 - 2026)
 
 #### Features
 
-- Aluminum Leaf Spring plate with addon plates: Carbon Fiber Leaf Spring and Polycarbonate plates
+- Aluminum Leaf Spring plate with addon plates: Carbon Fiber Leaf Spring, Polycarbonate and non-Leaf Spring Plate FR4 plates
 - Custom poron gasket strips
 - 6063 Aluminum
 - Sandblasted Brass and Stainless Steel weight
 - Tempered glass back cover
-- Solder and Hotswap PCB designed by Wolf
+- Solder and Hotswap PCB designed by Wolf and Zeix
 
 #### Changes from previous versions
 
-- Weight is now three-piece.
+- Weight is now three-piece, this changed assembly process.
+- Tempered glass back cover instead of acrylic.
 
 #### Colors
 
-- Autumn Lilac (Stainless steel weight)
-- British Racing Green (Sandblasted brass weight)
-- Smoke Grey (Stainless steel weight)
-- Lunar Black (Sandblasted brass weight)
-- Polycarbonate (Sandblasted brass weight)
-- Amethyst Purple (Stainless steel weight)
-- Imperial Red (Sandblasted brass weight)
+##### Base
+
+| Color                    | Weight            |
+| ------------------------ | ----------------- |
+| **Autumn Lilac**         | Stainless steel   |
+| **British Racing Green** | Sandblasted brass |
+| **Smoke Grey**           | Stainless steel   |
+| **Lunar Black**          | Sandblasted brass |
+
+##### Polycarbonate
+
+| Color             | Weight            |
+| ----------------- | ----------------- |
+| **Polycarbonate** | Sandblasted brass |
+| **Polycarbonate** | Stainless steel   |
+
+##### SMKX Colors
+
+| Year | Color               | Weight             |
+| ---- | ------------------- | ------------------ |
+| 2024 | **Amethyst Purple** | Stainless steel    |
+| 2025 | **Champagne Gold**  | Sandblasted copper |
+| 2025 | **Mocha Mousse**    | Stainless steel    |
+| 2026 | **Reseda Green**    | Sandblasted copper |
+
+##### Special Releases
+
+| Color            | Weight            |
+| ---------------- | ----------------- |
+| **Imperial Red** | Sandblasted brass |
+| **Berry Maroon** | Stainless steel   |
+| **Yale Blue**    | Stainless steel   |
+
+##### Collaborations
+
+| Collaboration                  | Colors         | Weight                                      |
+| ------------------------------ | -------------- | ------------------------------------------- |
+| Rubrehaku (Rubrehose x Kohaku) | **Gray and Beige** | Weight with fins, PC on Brass and Alu on SS |
+| Beloved (GMK Beloved x Kohaku) | **White and Pink** | Coated brass in pink and white              |
 
 ## Downloads
 

--- a/content/releases/neko.mdx
+++ b/content/releases/neko.mdx
@@ -3,28 +3,31 @@ import { Callout } from "nextra/components";
 # MONOKEI x SINGA Neko
 
 <Callout type={"warning"}>This page is a work in progress.</Callout>
+
 ## General Information
 
 The MONOKEI x SINGA Neko is a gasket mount 40-ish % keyboard in the HHKB layout. The cat motif is well known by now, with SINGA's, well, Singa75 and Jaguar a part of the growing keyboard / animal kingdom ruled by Elaine.
 
 ## Specifications
 
-**Form factor:** 40-ish % HHKB
-
-**Mounting Style:** Gasket mount
-
-**Typing Angle:** 6°
-
-**Dimensions:** 280mm x 100mm x 30mm
-
-**Front height:** 20mm
+| Spec               | Details               |
+| ------------------ | --------------------- |
+| **Form factor**    | 40-ish % HHKB         |
+| **Mounting Style** | Gasket mount          |
+| **Typing Angle**   | 6°                    |
+| **Dimensions**     | 280mm x 100mm x 30mm |
+| **Front height**   | 20mm                  |
 
 ## Layout
 
 ![Neko Solder](/Neko_Solder.png)
 ![Neko Hotswap](/Neko_Hotswap.png)
 
-## Colors
+## Changelog
+
+### R1 (2021)
+
+#### Colors
 
 - Blush Pink
 - Olive Green

--- a/content/releases/ocelot.mdx
+++ b/content/releases/ocelot.mdx
@@ -10,15 +10,14 @@ WIP
 
 ## Specifications
 
-**Form factor:** 8-key macropad
-
-**Mounting Style:** Integrated plate (R1), Top mount (R2)
-
-**Typing Angle:** WIP
-
-**Dimensions:** WIP
-
-**Front height:** WIP
+| Spec               | Details                               |
+| ------------------ | ------------------------------------- |
+| **Form factor**    | 8-key macropad                        |
+| **Mounting Style** | Integrated plate (R1), Top mount (R2) |
+| **Typing Angle**   | WIP                                   |
+| **Dimensions**     | WIP                                   |
+| **Front height**   | WIP                                   |
+| **Weight (R1)**    | 316g                                  |
 
 ## Layout
 
@@ -26,9 +25,9 @@ WIP
 
 ![Ocelot R1](/OcelotR1.png)
 
-### R2 (2022)
+### R2
 
-![Ocelot R1](/OcelotR2.png)
+![Ocelot R2](/OcelotR2.png)
 
 ## Changelog
 
@@ -38,7 +37,6 @@ WIP
 
 - 3mm integrated plate
 - Brass weight
-- Weight: 316g
 - QMK/VIA compatible
 - PCB designed by Wilba
 - USB-C
@@ -51,7 +49,7 @@ WIP
 - Black
 - Space Grey
 
-### R2 (2021)
+### R2 (2022)
 
 #### Changes from previous versions
 

--- a/content/releases/singa.mdx
+++ b/content/releases/singa.mdx
@@ -10,15 +10,13 @@ WIP
 
 ## Specifications
 
-**Form factor:** 75%
-
-**Mounting Style:** Top Mount
-
-**Typing Angle:** 8º
-
-**Dimensions:** WIP
-
-**Front height:** WIP
+| Spec               | Details   |
+| ------------------ | --------- |
+| **Form factor**    | 75%       |
+| **Mounting Style** | Top Mount |
+| **Typing Angle**   | 8°        |
+| **Dimensions**     | WIP       |
+| **Front height**   | WIP       |
 
 ## Layout
 
@@ -41,7 +39,7 @@ WIP
 
 #### Changes from previous versions
 
-- Stainless Steel Lion weight, Stainless Steel inner weight, Brass and Aluminum plates in the new colours.
+- Stainless Steel Lion weight, Stainless Steel inner weight, Brass and Aluminum plates in the new colors.
 - Added Winkey.
 
 #### Colors
@@ -54,9 +52,14 @@ WIP
 - Black (from R1)
 
 ### V3 (2020)
+
+#### Features
+
 - Wilba PCB for Aluminum units
 - Hineybush PCB for PC units
+
 #### Colors
+
 - Velvet
 - Sunset Orange
 - Rose Gold
@@ -64,4 +67,3 @@ WIP
 - Hydro Blue
 - E-White
 - Polycarbonate
-

--- a/content/releases/stinga.mdx
+++ b/content/releases/stinga.mdx
@@ -1,0 +1,33 @@
+import { Callout } from "nextra/components";
+
+# Stinga
+
+<Callout type={"warning"}>This page is a work in progress.</Callout>
+
+## General Information
+
+WIP
+
+## Specifications
+
+| Spec               | Details      |
+| ------------------ | ------------ |
+| **Form factor**    | 60%          |
+| **Mounting Style** | Gasket mount |
+| **Typing Angle**   | TBD          |
+| **Dimensions**     | TBD          |
+| **Front height**   | TBD          |
+
+## Changelog
+
+### R1 (TBD)
+
+#### Features
+
+- Coated brass weight
+
+#### Colors
+
+- Black
+- Red
+- Gray

--- a/content/releases/unikorn.mdx
+++ b/content/releases/unikorn.mdx
@@ -10,15 +10,13 @@ WIP
 
 ## Specifications
 
-**Form factor:** 60%
-
-**Mounting Style:** O-ring tray mount
-
-**Typing Angle:** 8°
-
-**Dimensions:** WIP
-
-**Front height:** 19mm
+| Spec               | Details           |
+| ------------------ | ----------------- |
+| **Form factor**    | 60%               |
+| **Mounting Style** | O-ring tray mount |
+| **Typing Angle**   | 8°                |
+| **Dimensions**     | WIP               |
+| **Front height**   | 19mm              |
 
 ## Layout
 
@@ -42,7 +40,7 @@ WIP
 
 ### R2 (2019)
 
-#### Color
+#### Colors
 
 - Black
 - Velvet

--- a/content/releases/unikorn.mdx
+++ b/content/releases/unikorn.mdx
@@ -14,7 +14,7 @@ WIP
 | ------------------ | ----------------- |
 | **Form factor**    | 60%               |
 | **Mounting Style** | O-ring tray mount |
-| **Typing Angle**   | 8°                |
+| **Typing Angle**   | 6° (R1) / 8° (R2+) |
 | **Dimensions**     | WIP               |
 | **Front height**   | 19mm              |
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.11",
     "@svgr/webpack": "^8.1.0",
-    "husky": "^8.0.0"
+    "husky": "^8.0.0",
+    "prettier": "^3.8.1"
   }
 }


### PR DESCRIPTION
## Summary

- Add new **Stinga** release page with specifications, changelog, and WIP callout
- Convert all Specifications sections to **tables with bold spec names** across all 7 releases
- Convert Kohaku color lists to **tables with Color/Weight columns** and bold color names
- Standardize section structure, fix typos, and correct inconsistencies (Ocelot year, Unikorn singular/plural, Singa spelling)
- Add **Prettier** as dev dependency for MDX file formatting

## Test plan

- [ ] Verify all release pages render correctly
- [ ] Check tables display properly on Stinga, Jaguar, Kohaku, Neko, Ocelot, Singa, and Unikorn pages
- [ ] Confirm Stinga appears in sidebar navigation
- [ ] Verify Kohaku color tables render with bold names and correct columns