### PR TITLE
Add Nextra Cards, Tabs, and frontmatter

### DIFF
--- a/content/index.mdx
+++ b/content/index.mdx
@@ -1,4 +1,8 @@
-import { Callout } from "nextra/components";
+---
+description: "Information repository for SINGAKBD keyboards — specs, layouts, changelogs, and downloads."
+---
+
+import { Cards, Callout } from "nextra/components";
 
 # Overview
 
@@ -8,3 +12,14 @@ This webpage serves as an information repository for SINGAKBD keyboards.
 The project itself is Open Source and the information presented is gathered from different sources including:
 [Geekhack](https://geekhack.org/index.php), [SINGAKBD.com](https://singakbd.com/) and the [SINGAKBD Discord](https://discord.com/invite/53Z8QCha).
 
+## Releases
+
+<Cards>
+  <Cards.Card title="SINGA" href="/releases/singa" />
+  <Cards.Card title="Jaguar" href="/releases/jaguar" />
+  <Cards.Card title="Kohaku" href="/releases/kohaku" />
+  <Cards.Card title="Neko (w. MONOKEI)" href="/releases/neko" />
+  <Cards.Card title="Ocelot" href="/releases/ocelot" />
+  <Cards.Card title="Unikorn (w. TGR)" href="/releases/unikorn" />
+  <Cards.Card title="Stinga" href="/releases/stinga" />
+</Cards>

--- a/content/releases/_meta.js
+++ b/content/releases/_meta.js
@@ -1,9 +1,9 @@
 export default {
-  jaguar: "🐆 Jaguar",
-  kohaku: "🐟 Kohaku",
-  neko: "🐈 Neko (w. MONOKEI)",
-  ocelot: "🐈‍⬛ Ocelot",
-  singa: "🦁 SINGA",
-  unikorn: "🦄 Unikorn (w. TGR)",
+  jaguar: "Jaguar",
+  kohaku: "Kohaku",
+  neko: "Neko (w. MONOKEI)",
+  ocelot: "Ocelot",
+  singa: "SINGA",
+  unikorn: "Unikorn (w. TGR)",
   stinga: "Stinga",
 };

--- a/content/releases/jaguar.mdx
+++ b/content/releases/jaguar.mdx
@@ -1,5 +1,9 @@
+---
+description: "Jaguar — 84/87 TKL keyboard by SINGAKBD. Specs, layouts, colors, and downloads."
+---
+
 import { DownloadIcon } from "@radix-ui/react-icons";
-import { Cards, Callout } from "nextra/components";
+import { Cards, Callout, Tabs } from "nextra/components";
 
 # Jaguar
 
@@ -21,14 +25,15 @@ WIP
 
 ## Layout
 
-### V1
-
-![Jaguar V1 Solder](/JaguarV1_Solder.png)
-
-### V2
-
-![Jaguar V2 Solder](/JaguarV2_Solder.png)
-![Jaguar V2 Hotswap](/JaguarV2_Hotswap.png)
+<Tabs items={["V1", "V2"]}>
+  <Tabs.Tab>
+    ![Jaguar V1 Solder](/JaguarV1_Solder.png)
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ![Jaguar V2 Solder](/JaguarV2_Solder.png)
+    ![Jaguar V2 Hotswap](/JaguarV2_Hotswap.png)
+  </Tabs.Tab>
+</Tabs>
 
 ## Changelog
 

--- a/content/releases/kohaku.mdx
+++ b/content/releases/kohaku.mdx
@@ -1,5 +1,9 @@
+---
+description: "Kohaku — 65% gasket mount keyboard by SINGAKBD. Specs, layouts, colors, and downloads."
+---
+
 import { DownloadIcon } from "@radix-ui/react-icons";
-import { Cards, Callout } from "nextra/components";
+import { Cards, Callout, Tabs } from "nextra/components";
 
 # Kohaku
 
@@ -22,15 +26,16 @@ WIP
 
 ## Layout
 
-### R1
-
-![Kohaku R1 Solder](/KohakuR1_Solder.png)
-![Kohaku R1 Hotswap](/KohakuR1_Hotswap.png)
-
-### R2
-
-![Kohaku R2 Solder](/KohakuR2_Solder.png)
-![Kohaku R2 Hotswap](/KohakuR2_Hotswap.png)
+<Tabs items={["R1", "R2"]}>
+  <Tabs.Tab>
+    ![Kohaku R1 Solder](/KohakuR1_Solder.png)
+    ![Kohaku R1 Hotswap](/KohakuR1_Hotswap.png)
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ![Kohaku R2 Solder](/KohakuR2_Solder.png)
+    ![Kohaku R2 Hotswap](/KohakuR2_Hotswap.png)
+  </Tabs.Tab>
+</Tabs>
 
 ## Changelog
 

--- a/content/releases/neko.mdx
+++ b/content/releases/neko.mdx
@@ -1,3 +1,7 @@
+---
+description: "MONOKEI x SINGA Neko — 40-ish% HHKB gasket mount keyboard. Specs, layouts, and colors."
+---
+
 import { Callout } from "nextra/components";
 
 # MONOKEI x SINGA Neko

--- a/content/releases/ocelot.mdx
+++ b/content/releases/ocelot.mdx
@@ -1,4 +1,8 @@
-import { Callout } from "nextra/components";
+---
+description: "Ocelot — 8-key macropad by SINGAKBD. Specs, layouts, and colors."
+---
+
+import { Callout, Tabs } from "nextra/components";
 
 # Ocelot
 
@@ -21,13 +25,14 @@ WIP
 
 ## Layout
 
-### R1
-
-![Ocelot R1](/OcelotR1.png)
-
-### R2
-
-![Ocelot R2](/OcelotR2.png)
+<Tabs items={["R1", "R2"]}>
+  <Tabs.Tab>
+    ![Ocelot R1](/OcelotR1.png)
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ![Ocelot R2](/OcelotR2.png)
+  </Tabs.Tab>
+</Tabs>
 
 ## Changelog
 

--- a/content/releases/singa.mdx
+++ b/content/releases/singa.mdx
@@ -1,3 +1,7 @@
+---
+description: "SINGA — 75% top mount keyboard by SINGAKBD. Specs, layouts, and colors across V1-V3."
+---
+
 import { Callout } from "nextra/components";
 
 # SINGA

--- a/content/releases/stinga.mdx
+++ b/content/releases/stinga.mdx
@@ -1,3 +1,7 @@
+---
+description: "Stinga — 60% gasket mount keyboard by SINGAKBD. Specs and colors."
+---
+
 import { Callout } from "nextra/components";
 
 # Stinga

--- a/content/releases/unikorn.mdx
+++ b/content/releases/unikorn.mdx
@@ -1,3 +1,7 @@
+---
+description: "TGR x SINGA Unikorn — 60% O-ring tray mount keyboard. Specs, layouts, and colors across R1-R2.2."
+---
+
 import { Callout } from "nextra/components";
 
 # TGR x SINGA Unikorn


### PR DESCRIPTION
## Summary
- Add Cards grid on home page for a visual release overview
- Add Tabs component for layout images on multi-version pages (Jaguar, Kohaku, Ocelot)
- Add frontmatter `description` to all MDX pages for SEO/OpenGraph
- Remove emojis from sidebar labels and cards

## Test plan
- [ ] Verify Cards render on the home page and link correctly
- [ ] Verify Tabs switch between layout versions on Jaguar, Kohaku, Ocelot
- [ ] Verify sidebar labels no longer have emojis
- [ ] Verify OpenGraph descriptions appear in page source