### PR TITLE
Add download links to all release pages

### DIFF
--- a/content/releases/jaguar.mdx
+++ b/content/releases/jaguar.mdx
@@ -76,12 +76,22 @@ Commissions for this iteration of Jaguar were made available.
 
 ## Downloads
 
+### Jaguar V1
+
+<Cards>
+  <Cards.Card
+    icon={<DownloadIcon />}
+    title="VIA firmware"
+    href="https://caniusevia.com/docs/download_firmware#0"
+  />
+</Cards>
+
 ### Jaguar V2
 
 <Cards>
   <Cards.Card
     icon={<DownloadIcon />}
     title="Plate files"
-    href="https://www.dropbox.com/scl/fo/z0l4ui8v8dnfm7634fdcf/h?rlkey=vz5bxljaryp5i6ufrpm2xzwt9&dl=0"
+    href="https://www.dropbox.com/scl/fo/z0l4ui8v8dnfm7634fdcf/ADOjnVDgg3wgyV_7z0OjCos?rlkey=l684up3ifssrd0zviw3i3g8iv&st=aysit4kc&dl=0"
   />
 </Cards>

--- a/content/releases/kohaku.mdx
+++ b/content/releases/kohaku.mdx
@@ -124,7 +124,7 @@ WIP
   <Cards.Card
     icon={<DownloadIcon />}
     title="Plate files"
-    href="https://www.dropbox.com/sh/8o0mistsdhxo12f/AAD2j4ivmD6rQHQvsmLEqa1la?dl=0"
+    href="https://www.dropbox.com/scl/fo/3yi3n44uc4fftupg7zd0m/ACdMtmyCsD4Bor_fTxovpq4?rlkey=yweb6apegbxxe12qsan905lt1&st=qlhktynv&dl=0"
   />
   <Cards.Card
     icon={<DownloadIcon />}

--- a/content/releases/ocelot.mdx
+++ b/content/releases/ocelot.mdx
@@ -2,7 +2,8 @@
 description: "Ocelot — 8-key macropad by SINGAKBD. Specs, layouts, and colors."
 ---
 
-import { Callout, Tabs } from "nextra/components";
+import { DownloadIcon } from "@radix-ui/react-icons";
+import { Cards, Callout, Tabs } from "nextra/components";
 
 # Ocelot
 
@@ -69,3 +70,25 @@ WIP
 - Indigo (Purple)
 - Polycarbonate
 - Black w/ Copper weight
+
+## Downloads
+
+### Ocelot R1
+
+<Cards>
+  <Cards.Card
+    icon={<DownloadIcon />}
+    title="VIA firmware"
+    href="https://caniusevia.com/docs/download_firmware#0"
+  />
+</Cards>
+
+### Ocelot R2
+
+<Cards>
+  <Cards.Card
+    icon={<DownloadIcon />}
+    title="Plate files and Xstand files"
+    href="https://www.dropbox.com/scl/fo/5ar0mqmrost53syvaqcs9/h?dl=0&rlkey=hinb22eumr12lhe59f6zcifg8"
+  />
+</Cards>

--- a/content/releases/singa.mdx
+++ b/content/releases/singa.mdx
@@ -2,7 +2,8 @@
 description: "SINGA — 75% top mount keyboard by SINGAKBD. Specs, layouts, and colors across V1-V3."
 ---
 
-import { Callout } from "nextra/components";
+import { DownloadIcon } from "@radix-ui/react-icons";
+import { Cards, Callout } from "nextra/components";
 
 # SINGA
 
@@ -71,3 +72,15 @@ WIP
 - Hydro Blue
 - E-White
 - Polycarbonate
+
+## Downloads
+
+### SINGA R1
+
+<Cards>
+  <Cards.Card
+    icon={<DownloadIcon />}
+    title="VIA firmware"
+    href="https://caniusevia.com/docs/download_firmware#0"
+  />
+</Cards>

--- a/content/releases/unikorn.mdx
+++ b/content/releases/unikorn.mdx
@@ -2,7 +2,8 @@
 description: "TGR x SINGA Unikorn — 60% O-ring tray mount keyboard. Specs, layouts, and colors across R1-R2.2."
 ---
 
-import { Callout } from "nextra/components";
+import { DownloadIcon } from "@radix-ui/react-icons";
+import { Cards, Callout } from "nextra/components";
 
 # TGR x SINGA Unikorn
 
@@ -94,4 +95,32 @@ WIP
 
 ## Downloads
 
-WIP
+### Unikorn R1
+
+<Cards>
+  <Cards.Card
+    icon={<DownloadIcon />}
+    title="VIA firmware"
+    href="https://caniusevia.com/docs/download_firmware/#0"
+  />
+</Cards>
+
+### Unikorn R2.1
+
+<Cards>
+  <Cards.Card
+    icon={<DownloadIcon />}
+    title="VIA firmware"
+    href="https://caniusevia.com/docs/download_firmware#0"
+  />
+</Cards>
+
+### Unikorn R2.2
+
+<Cards>
+  <Cards.Card
+    icon={<DownloadIcon />}
+    title="Plate files"
+    href="https://www.dropbox.com/sh/fsugpwxhf0oci4y/AADmx93LBIJ6KrStfjzNC0aGa?dl=0"
+  />
+</Cards>


### PR DESCRIPTION
## Summary
- Add VIA firmware download links for Singa R1, Ocelot R1, Unikorn R1/R2.1, Jaguar V1
- Add Dropbox plate/Xstand file links for Ocelot R2, Unikorn R2.2
- Update Jaguar V2 and Kohaku R1 Dropbox URLs to match current singakbd.com/pages/downloads

## Test plan
- [ ] Verify all download cards render and link correctly
- [ ] Verify Dropbox links open to the correct folders
- [ ] Verify VIA firmware links resolve