### PR TITLE
Add Kohaku R2, PC Kohaku & Kyohaku, and Rubrehaku downloads

### DIFF
--- a/content/releases/kohaku.mdx
+++ b/content/releases/kohaku.mdx
@@ -118,7 +118,7 @@ WIP
 
 ## Downloads
 
-### Kohaku R1
+### Kohaku R1 & R2
 
 <Cards>
   <Cards.Card
@@ -130,5 +130,35 @@ WIP
     icon={<DownloadIcon />}
     title="Back cover files"
     href="https://www.dropbox.com/sh/lhjtf5qd7r6qv05/AAA96XXSp47ewNZvHsr1l3ZGa?dl=0"
+  />
+</Cards>
+
+### Kohaku R2
+
+<Cards>
+  <Cards.Card
+    icon={<DownloadIcon />}
+    title="Firmware and VIA JSONs"
+    href="https://www.dropbox.com/scl/fo/jb022wi7l4ks9pd4gfyuo/AKrLpk6Tr7vb6G9FfvhTjr8?rlkey=1rjwxkvfd5d58db2do5tnjshq&st=jhuu2im7&dl=0"
+  />
+</Cards>
+
+### PC Kohaku & Kyohaku
+
+<Cards>
+  <Cards.Card
+    icon={<DownloadIcon />}
+    title="Firmware and VIA JSONs"
+    href="https://www.dropbox.com/scl/fo/wzxvc8c0d7fhuc2z9g6yb/AMVg_HVyfMaJ4No8CbRicNI?rlkey=dv9vgks1kxtt8jixpak00pr8y&st=0dir7mmk&dl=0"
+  />
+</Cards>
+
+### Rubrehaku
+
+<Cards>
+  <Cards.Card
+    icon={<DownloadIcon />}
+    title="Firmware and plate files"
+    href="https://www.dropbox.com/scl/fo/6zgxzf9qymwsovdhzz3aq/AIvDUOzrYpnzNHU9tVuUTlI?rlkey=mlfn4zbr4v28w6hchy93oacg7&e=1&st=nr6beyan&dl=0"
   />
 </Cards>


### PR DESCRIPTION
## Summary
- Group Kohaku R1 & R2 plate files and back cover under shared heading
- Add Kohaku R2 firmware and VIA JSONs download link
- Add PC Kohaku & Kyohaku firmware and VIA JSONs download link
- Add Rubrehaku firmware and plate files download link

## Test plan
- [ ] Verify all new download cards render and link correctly