### PR TITLE
Add GUNDAMHAKU collaboration to Kohaku

### DIFF
--- a/content/releases/kohaku.mdx
+++ b/content/releases/kohaku.mdx
@@ -115,6 +115,7 @@ WIP
 | ------------------------------ | -------------- | ------------------------------------------- |
 | Rubrehaku (Rubrehose x Kohaku) | **Gray and Beige** | Weight with fins, PC on Brass and Alu on SS |
 | Beloved (GMK Beloved x Kohaku) | **White and Pink** | Coated brass in pink and white              |
+| [GUNDAMHAKU](https://singakbd.com/pages/gundamhaku) (Mobile Suit Gundam SEED x SINGAKBD) | **Blue and White** | Sandblasted stainless steel with mirror polished accents |
 
 ## Downloads
 


### PR DESCRIPTION
## Summary
- Add GUNDAMHAKU (Mobile Suit Gundam SEED x SINGAKBD) to Kohaku collaborations table
- Blue and White colors, sandblasted stainless steel weight with mirror polished accents
- Links to singakbd.com product page

## Test plan
- [x] Verify collaboration row renders correctly in the table
- [x] Verify link to singakbd.com page works