### PR TITLE
Specify finish types for Kohaku collaboration colors

### DIFF
--- a/content/releases/kohaku.mdx
+++ b/content/releases/kohaku.mdx
@@ -113,9 +113,9 @@ WIP
 
 | Collaboration                  | Colors         | Weight                                      |
 | ------------------------------ | -------------- | ------------------------------------------- |
-| Rubrehaku (Rubrehose x Kohaku) | **Gray and Beige** | Weight with fins, PC on Brass and Alu on SS |
-| Beloved (GMK Beloved x Kohaku) | **White and Pink** | Coated brass in pink and white              |
-| [GUNDAMHAKU](https://singakbd.com/pages/gundamhaku) (Mobile Suit Gundam SEED x SINGAKBD) | **Blue and White** | Sandblasted stainless steel with mirror polished accents |
+| Rubrehaku (Rubrehose x Kohaku) | **Gray (Anodized) and Beige (Coating)** | Weight with fins, PC on Brass and Alu on SS |
+| Beloved (GMK Beloved x Kohaku) | **White (Coating) and Pink (Coating)** | Coated brass in pink and white              |
+| [GUNDAMHAKU](https://singakbd.com/pages/gundamhaku) (Mobile Suit Gundam SEED x SINGAKBD) | **Blue (Anodized) and White (Coating)** | Sandblasted stainless steel with mirror polished accents |
 
 ## Downloads
 


### PR DESCRIPTION
## Summary
- Add anodized/coating finish types to Kohaku collaboration color entries (Rubrehaku, Beloved, GUNDAMHAKU)

## Test plan
- [ ] Verify collaboration table renders correctly