### PR TITLE
Separate Kohaku collaboration colors with finish column

### DIFF
--- a/content/releases/kohaku.mdx
+++ b/content/releases/kohaku.mdx
@@ -111,11 +111,14 @@ WIP
 
 ##### Collaborations
 
-| Collaboration                  | Colors         | Weight                                      |
-| ------------------------------ | -------------- | ------------------------------------------- |
-| Rubrehaku (Rubrehose x Kohaku) | **Gray (Anodized) and Beige (Coating)** | Weight with fins, PC on Brass and Alu on SS |
-| Beloved (GMK Beloved x Kohaku) | **White (Coating) and Pink (Coating)** | Coated brass in pink and white              |
-| [GUNDAMHAKU](https://singakbd.com/pages/gundamhaku) (Mobile Suit Gundam SEED x SINGAKBD) | **Blue (Anodized) and White (Coating)** | Sandblasted stainless steel with mirror polished accents |
+| Collaboration                  | Color      | Finish    | Weight                                      |
+| ------------------------------ | ---------- | --------- | ------------------------------------------- |
+| Rubrehaku (Rubrehose x Kohaku) | **Gray**   | Anodized  | Weight with fins, PC on Brass and Alu on SS |
+| Rubrehaku (Rubrehose x Kohaku) | **Beige**  | Coated    | Weight with fins, PC on Brass and Alu on SS |
+| Beloved (GMK Beloved x Kohaku) | **White**  | Coated    | Coated brass in pink                        |
+| Beloved (GMK Beloved x Kohaku) | **Pink**   | Coated    | Coated brass in white                       |
+| [GUNDAMHAKU](https://singakbd.com/pages/gundamhaku) (Mobile Suit Gundam SEED x SINGAKBD) | **Blue**   | Anodized  | Sandblasted stainless steel with mirror polished accents |
+| [GUNDAMHAKU](https://singakbd.com/pages/gundamhaku) (Mobile Suit Gundam SEED x SINGAKBD) | **White**  | Coated    | Sandblasted stainless steel with mirror polished accents |
 
 ## Downloads
 


### PR DESCRIPTION
## Summary
- Split collaboration colors into individual rows
- Add Finish column (Anodized/Coated)
- Fix Beloved weight colors (white case → pink weight, pink case → white weight)

## Test plan
- [ ] Verify collaboration table renders correctly